### PR TITLE
Fix front matter and template placeholder rendering

### DIFF
--- a/draft-ietf-mediaman-6838bis.md
+++ b/draft-ietf-mediaman-6838bis.md
@@ -4,7 +4,7 @@ abbrev: Media Type Registration
 docname: draft-ietf-mediaman-6838bis-latest
 date:
 category: bcp
-obsoletes: [6838, 9694]
+obsoletes: 6838, 9694
 
 ipr: trust200902
 keyword: Internet-Draft
@@ -13,7 +13,10 @@ stand_alone: yes
 smart_quotes: no
 pi: [toc, tocindent, sortrefs, symrefs, strict, compact, comments, inline]
 
+workgroup: Media Type Maintenance
+
 venue:
+  group: Media Type Maintenance
   home: "https://datatracker.ietf.org/wg/mediaman/about/"
   repo: "https://github.com/ietf-wg-mediaman/6838bis/"
 
@@ -547,36 +550,36 @@ If the Designated Expert(s) find that the change controller is unresponsive or u
 
 {:vspace}
 Type name:
-: [see {{naming}}]
+: \[see {{naming}}\]
 
 Subtype name:
-: [see {{naming}}]
+: \[see {{naming}}\]
 
 Required parameters:
-: [see {{parameters}}]
+: \[see {{parameters}}\]
 
 Optional parameters:
-: [see {{parameters}}]
+: \[see {{parameters}}\]
 
 Encoding considerations:
-: [see {{encoding}}]
+: \[see {{encoding}}\]
 
 Security considerations:
-: [see {{secreq}}]
+: \[see {{secreq}}\]
 
 Interoperability considerations:
-: [see {{interop}}]
+: \[see {{interop}}\]
 
 Published specification:
-: [see {{spec}}]
+: \[see {{spec}}\]
 
 Applications that use this media type:
 
 {:vspace}
 Fragment identifier considerations:
-: [see {{fragments}}]
+: \[see {{fragments}}\]
 
-Additional information: [see {{additional}}]
+Additional information: \[see {{additional}}\]
 : Deprecated alias names for this type:
 
   Magic number(s):
@@ -589,19 +592,19 @@ Additional information: [see {{additional}}]
 
 {:vspace}
 Person & email address to contact for further information:
-: [see {{contacts}}]
+: \[see {{contacts}}\]
 
 Intended usage:
-: [see {{usage}}]
+: \[see {{usage}}\]
 
 Restrictions on usage:
-: [see {{usage}}]
+: \[see {{usage}}\]
 
 Author:
-: [see {{contacts}}]
+: \[see {{contacts}}\]
 
 Change controller:
-: [see {{contacts}}]
+: \[see {{contacts}}\]
 
 (Any other information that the author deems interesting may be added below this line.)
 


### PR DESCRIPTION
[AI-assisted review of the editor's copy, reviewed by me before sending.]

Three rendering bugs. No text change.

**`obsoletes` renders as `[6838, 9694]`.** It was a YAML list, which kramdown stringifies with the brackets intact. A plain comma-separated value gives `obsoletes="6838, 9694"`.

**"About This Document" begins mid-sentence** — "information can be found at https://datatracker.ietf.org/wg/mediaman/about/." The boilerplate is "*&lt;group&gt;* Working Group information can be found at …" and there was no workgroup name to fill it.

**15 build warnings from the registration templates.** `: [see {{usage}}]` is parsed as a reference-style link `[see {{usage}}]` with no matching definition, once per placeholder in §5.6 and §6.2:

```
- No link definition for link ID 'see {{naming}}' found on line 598
  ... 15 of these
```

Escaping the brackets takes it to zero. I diffed the generated XML before and after: identical apart from the added workgroup name, so the placeholders still render as `[see Section 2.3]`.
